### PR TITLE
v0.4.0 fix: make Windows rollback test deterministic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,6 +219,7 @@ jobs:
               -NewRoot $package -TargetRoot $rollbackTarget -Stopper (Join-Path $rollbackTarget "runtime\stop-council.ps1") `
               -LogFile (Join-Path $env:RUNNER_TEMP "rollback.log") -ResultFile (Join-Path $env:RUNNER_TEMP "rollback-result.json")
             $rollbackExit = $LASTEXITCODE
+            $global:LASTEXITCODE = 0
           } finally {
             $locked.Dispose()
           }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,7 +211,9 @@ jobs:
           Copy-Item -Recurse $package $rollbackTarget
           Set-Content -Encoding ASCII -Path (Join-Path $rollbackTarget "VERSION") -Value "0.0.1"
           Set-Content -Encoding ASCII -Path (Join-Path $rollbackTarget "previous-version.txt") -Value "keep me"
-          $locked = [System.IO.File]::Open((Join-Path $package "README-FIRST.txt"), "Open", "Read", "None")
+          $lockedSource = Join-Path $package "force-copy-failure.txt"
+          Set-Content -Encoding ASCII -Path $lockedSource -Value "this source-only file must be copied"
+          $locked = [System.IO.File]::Open($lockedSource, "Open", "Read", "None")
           try {
             & powershell.exe -NoProfile -ExecutionPolicy Bypass -File (Join-Path $package "runtime\update-council.ps1") `
               -NewRoot $package -TargetRoot $rollbackTarget -Stopper (Join-Path $rollbackTarget "runtime\stop-council.ps1") `


### PR DESCRIPTION
## Summary

Make the Windows updater rollback smoke test deterministic. The old test locked a source file that already existed unchanged in the target, so `robocopy` legitimately skipped it and the update succeeded. The revised test creates a source-only file and locks it, forcing the replacement copy to fail while leaving the backup and target available for rollback.

## Verification

- [x] Release workflow YAML parses successfully
- [x] `git diff --check`
- [ ] GitHub Windows runner must prove the forced copy failure restores version `0.0.1`, preserves the previous-version marker, and writes an error result

This changes only release-test fault injection. Application runtime code and published package contents are unchanged.
