### PR TITLE
v0.7.0 fix: make macOS release check Bash 3 compatible

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,8 @@ jobs:
           curl -fsS -c "$cookie_jar" -H 'Origin: http://127.0.0.1:3000' -H 'Content-Type: application/json' --data "{\"token\":\"$token\"}" http://127.0.0.1:3000/mobile-access/pair | grep -q '"paired":true'
           curl -fsS -b "$cookie_jar" http://127.0.0.1:3000/ | grep -q Council
           curl -fsS -b "$cookie_jar" http://127.0.0.1:3000/api/health | grep -q council-lab
-          test "$(curl -sS -o /dev/null -w '%{http_code}' -H 'Origin: http://127.0.0.1:3000' -H 'Content-Type: application/json' --data "{\"token\":\"$token\",\"device\":\"desktop\"}" http://127.0.0.1:3000/mobile-access/pair)" = "403"
+          mobile_desktop_status="$(curl -sS -o /dev/null -w '%{http_code}' -H 'Origin: http://127.0.0.1:3000' -H 'Content-Type: application/json' --data "{\"token\":\"$token\",\"device\":\"desktop\"}" http://127.0.0.1:3000/mobile-access/pair)"
+          [[ "$mobile_desktop_status" == "403" ]]
           desktop_cookie="$RUNNER_TEMP/launcher-desktop-cookie.txt"
           curl -fsS -c "$desktop_cookie" -H 'Origin: http://127.0.0.1:3000' -H 'Content-Type: application/json' --data "{\"token\":\"$desktop_token\",\"device\":\"desktop\"}" http://127.0.0.1:3000/mobile-access/pair | grep -q '"paired":true'
           curl -fsS -b "$desktop_cookie" http://127.0.0.1:3000/mobile-access/info | grep -q '"activeSessions":1'


### PR DESCRIPTION
## Summary

- Preserve the mobile-token authority regression check in the macOS Release smoke test.
- Capture the HTTP status before comparing it, avoiding Bash 3.2 argument parsing failure around command substitution and nested JSON quoting.

## Verification

- Release workflow YAML parses successfully.
- The extracted macOS smoke-test script passes `/bin/bash -n` on macOS Bash 3.2.
- The equivalent status comparison executes successfully.
- Release consistency check passes for v0.7.0.

## Failure evidence

The first v0.7.0 Release run built the macOS package successfully, then stopped at this assertion with `test: too many arguments`. Windows packaging and all pre-release quality gates passed.