### PR TITLE
fix: isolate live frontend build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ backend/data/
 # Frontend
 frontend/node_modules/
 frontend/.next/
+frontend/.next-runtime/
+frontend/.next-release/
 frontend/test-results/
 frontend/playwright-report/
 *.tsbuildinfo

--- a/backend/tests/test_release_consistency.py
+++ b/backend/tests/test_release_consistency.py
@@ -35,6 +35,24 @@ def test_release_metadata_is_consistent():
     assert result.returncode == 0, result.stderr
 
 
+def test_source_desktop_runtime_build_is_isolated_from_validation_and_release_builds():
+    next_config = (ROOT / "frontend/next.config.ts").read_text(encoding="utf-8")
+    mac_launcher = (ROOT / "desktop/start-council.sh").read_text(encoding="utf-8")
+    windows_launcher = (ROOT / "desktop/start-council.ps1").read_text(encoding="utf-8")
+    installer = (ROOT / "setup.sh").read_text(encoding="utf-8")
+    windows_installer = (ROOT / "desktop/install-windows.ps1").read_text(encoding="utf-8")
+    mac_release = (ROOT / "packaging/build-macos-release.sh").read_text(encoding="utf-8")
+    windows_release = (ROOT / "packaging/build-windows-release.ps1").read_text(encoding="utf-8")
+
+    assert "COUNCIL_NEXT_DIST_DIR" in next_config
+    for script in (mac_launcher, windows_launcher, installer, windows_installer):
+        assert ".next-runtime" in script
+        assert "COUNCIL_NEXT_DIST_DIR" in script
+    for script in (mac_release, windows_release):
+        assert ".next-release" in script
+        assert "COUNCIL_NEXT_DIST_DIR" in script
+
+
 def copy_release_files(tmp_path: Path) -> None:
     for relative_path in REQUIRED_FILES:
         source = ROOT / relative_path

--- a/desktop/install-windows.ps1
+++ b/desktop/install-windows.ps1
@@ -72,13 +72,17 @@ try {
 
     Write-Host "2/3 Installing and building the web interface..."
     Push-Location $FrontendDir
+    $PreviousNextDistDir = $env:COUNCIL_NEXT_DIST_DIR
     try {
         & $Npm.Source ci --no-audit --no-fund
         if ($LASTEXITCODE -ne 0) { Stop-Install "Frontend dependency installation failed." }
+        $env:COUNCIL_NEXT_DIST_DIR = ".next-runtime"
         & $Npm.Source run build
         if ($LASTEXITCODE -ne 0) { Stop-Install "Frontend build failed." }
     }
     finally {
+        if ($null -eq $PreviousNextDistDir) { Remove-Item Env:COUNCIL_NEXT_DIST_DIR -ErrorAction SilentlyContinue }
+        else { $env:COUNCIL_NEXT_DIST_DIR = $PreviousNextDistDir }
         Pop-Location
     }
 

--- a/desktop/start-council.ps1
+++ b/desktop/start-council.ps1
@@ -7,7 +7,8 @@ $ErrorActionPreference = "Stop"
 $ProjectDir = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
 $BackendPython = Join-Path $ProjectDir "backend\.venv\Scripts\python.exe"
 $NextScript = Join-Path $ProjectDir "frontend\node_modules\next\dist\bin\next"
-$BuildId = Join-Path $ProjectDir "frontend\.next\BUILD_ID"
+$FrontendDistDir = ".next-runtime"
+$BuildId = Join-Path $ProjectDir "frontend\$FrontendDistDir\BUILD_ID"
 $LocalRoot = if ($env:LOCALAPPDATA) { $env:LOCALAPPDATA } else { Join-Path $HOME "AppData\Local" }
 $LogDir = if ($env:COUNCIL_LOG_DIR) { $env:COUNCIL_LOG_DIR } else { Join-Path $LocalRoot "Council\logs" }
 $PidFile = Join-Path $LogDir "council-pids.json"
@@ -95,8 +96,10 @@ try {
         Set-Content -Encoding ASCII -Path $DesktopTokenFile -Value $DesktopToken
         $PreviousRemoteToken = $env:COUNCIL_REMOTE_TOKEN
         $PreviousDesktopToken = $env:COUNCIL_DESKTOP_TOKEN
+        $PreviousNextDistDir = $env:COUNCIL_NEXT_DIST_DIR
         $env:COUNCIL_REMOTE_TOKEN = $RemoteToken
         $env:COUNCIL_DESKTOP_TOKEN = $DesktopToken
+        $env:COUNCIL_NEXT_DIST_DIR = $FrontendDistDir
         try {
             $Node = (Get-Command "node.exe" -ErrorAction Stop).Source
             $FrontendProcess = Start-Process -FilePath $Node `
@@ -111,6 +114,8 @@ try {
             else { $env:COUNCIL_REMOTE_TOKEN = $PreviousRemoteToken }
             if ($null -eq $PreviousDesktopToken) { Remove-Item Env:COUNCIL_DESKTOP_TOKEN -ErrorAction SilentlyContinue }
             else { $env:COUNCIL_DESKTOP_TOKEN = $PreviousDesktopToken }
+            if ($null -eq $PreviousNextDistDir) { Remove-Item Env:COUNCIL_NEXT_DIST_DIR -ErrorAction SilentlyContinue }
+            else { $env:COUNCIL_NEXT_DIST_DIR = $PreviousNextDistDir }
         }
         if (-not (Wait-Until { Test-Frontend })) {
             throw "The web interface did not start. See $LogDir\frontend.stderr.log"

--- a/desktop/start-council.sh
+++ b/desktop/start-council.sh
@@ -7,6 +7,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 BACKEND_DIR="$PROJECT_DIR/backend"
 FRONTEND_DIR="$PROJECT_DIR/frontend"
+FRONTEND_DIST_DIR=".next-runtime"
 LOG_DIR="${COUNCIL_LOG_DIR:-$HOME/Library/Logs/Council}"
 PID_FILE="$LOG_DIR/council.pids"
 BACKEND_LOG="$LOG_DIR/backend.log"
@@ -41,7 +42,7 @@ if [[ ! -x "$BACKEND_DIR/.venv/bin/uvicorn" ]]; then
   exit 1
 fi
 
-if [[ ! -x "$FRONTEND_DIR/node_modules/next/dist/bin/next" || ! -f "$FRONTEND_DIR/.next/BUILD_ID" ]]; then
+if [[ ! -x "$FRONTEND_DIR/node_modules/next/dist/bin/next" || ! -f "$FRONTEND_DIR/$FRONTEND_DIST_DIR/BUILD_ID" ]]; then
   osascript -e 'display dialog "网页尚未构建。请双击项目文件夹里的“安装 Council.command”。" buttons {"好"} with title "Council 无法启动"' >/dev/null 2>&1 || true
   exit 1
 fi
@@ -83,7 +84,7 @@ if ! frontend_is_up; then
   printf '%s\n' "$REMOTE_TOKEN" > "$TOKEN_FILE"
   printf '%s\n' "$DESKTOP_TOKEN" > "$DESKTOP_TOKEN_FILE"
   pushd "$FRONTEND_DIR" >/dev/null
-  COUNCIL_REMOTE_TOKEN="$REMOTE_TOKEN" COUNCIL_DESKTOP_TOKEN="$DESKTOP_TOKEN" nohup "$FRONTEND_DIR/node_modules/next/dist/bin/next" start -H 0.0.0.0 -p 3000 >>"$FRONTEND_LOG" 2>&1 &
+  COUNCIL_NEXT_DIST_DIR="$FRONTEND_DIST_DIR" COUNCIL_REMOTE_TOKEN="$REMOTE_TOKEN" COUNCIL_DESKTOP_TOKEN="$DESKTOP_TOKEN" nohup "$FRONTEND_DIR/node_modules/next/dist/bin/next" start -H 0.0.0.0 -p 3000 >>"$FRONTEND_LOG" 2>&1 &
   FRONTEND_PID=$!
   popd >/dev/null
   echo "frontend $FRONTEND_PID" >>"$PID_FILE"

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -3,6 +3,7 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   devIndicators: false,
+  distDir: process.env.COUNCIL_NEXT_DIST_DIR || ".next",
   output: process.env.COUNCIL_STANDALONE === "1" ? "standalone" : undefined,
   async rewrites() {
     const backendUrl = process.env.COUNCIL_BACKEND_URL || "http://127.0.0.1:8001";

--- a/frontend/tests/smoke.spec.ts
+++ b/frontend/tests/smoke.spec.ts
@@ -576,7 +576,7 @@ test("移动端圆桌固定一屏，内部消息区滚动", async ({ page, reque
 test("席位失败时明确显示原因并允许从当前席位重试", async ({ page }) => {
   const failedRun = {
     id: "failed-fixture",
-    question: "我想睡觉",
+    question: "首席还没有发言就超时",
     mode: "standard",
     provider_id: "ccswitch",
     model: "test-reasoning-model",
@@ -591,14 +591,14 @@ test("席位失败时明确显示原因并允许从当前席位重试", async ({
     error: "当前席位等待上游超过 120 秒，CC Switch 未能在时限内返回结果。请重试当前席位。",
     degraded: true,
     protocol: "auto",
-    discussion_turns: [{ id: "analyst-turn", speaker_type: "agent", speaker_id: "analyst", speaker_name: "析理", role_label: "拆解者", content: "第一席已经完成。", round: 1, created_at: new Date().toISOString() }],
+    discussion_turns: [],
     participant_roles: [
       { id: "analyst", name: "析理", role: "拆解者", brief: "拆解问题" },
       { id: "challenger", name: "诘问", role: "挑战者", brief: "寻找反例" },
       { id: "builder", name: "构策", role: "方案师", brief: "提出方案" },
       { id: "observer", name: "观澜", role: "观察者", brief: "观察分歧" },
     ],
-    current_speaker_index: 1,
+    current_speaker_index: 0,
     discussion_round: 1,
     awaiting_user: false,
   };
@@ -612,8 +612,9 @@ test("席位失败时明确显示原因并允许从当前席位重试", async ({
   await page.goto("/runs/failed-fixture");
   await expect(page.getByText("调用失败", { exact: true }).first()).toBeVisible();
   await expect(page.getByText(/等待上游超过 120 秒/)).toBeVisible();
-  await expect(page.locator(".council-seat.failed")).toContainText("诘问");
-  await page.getByRole("button", { name: "重试诘问" }).click();
+  await expect(page.getByText("0 次 AI 发言 · 0 次你的参与", { exact: true })).toBeVisible();
+  await expect(page.locator(".council-seat.failed")).toContainText("析理");
+  await page.getByRole("button", { name: "重试析理" }).click();
   expect(retryRequested).toBeTruthy();
 });
 

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -28,7 +28,11 @@
     ".next/types/**/*.ts",
     "**/*.ts",
     "**/*.tsx",
-    ".next/dev/types/**/*.ts"
+    ".next/dev/types/**/*.ts",
+    ".next-runtime/types/**/*.ts",
+    ".next-runtime/dev/types/**/*.ts",
+    ".next-release/types/**/*.ts",
+    ".next-release/dev/types/**/*.ts"
   ],
   "exclude": [
     "node_modules"

--- a/packaging/build-macos-release.sh
+++ b/packaging/build-macos-release.sh
@@ -21,6 +21,7 @@ esac
 NODE_RUNTIME_NAME="node-v${NODE_RUNTIME_VERSION}-darwin-${NODE_RUNTIME_ARCH}"
 NODE_RUNTIME_ARCHIVE="$PROJECT_DIR/build/${NODE_RUNTIME_NAME}.tar.gz"
 NODE_RUNTIME_DIR="$PROJECT_DIR/build/$NODE_RUNTIME_NAME"
+RELEASE_DIST_DIR=".next-release"
 
 if [[ "$PYTHON_BIN" != */* ]]; then
   PYTHON_BIN="$(command -v "$PYTHON_BIN" || true)"
@@ -45,7 +46,7 @@ fi
 
 pushd "$PROJECT_DIR/frontend" >/dev/null
 npm ci --no-audit --no-fund
-COUNCIL_STANDALONE=1 npm run build
+COUNCIL_NEXT_DIST_DIR="$RELEASE_DIST_DIR" COUNCIL_STANDALONE=1 npm run build
 popd >/dev/null
 
 "$PYTHON_BIN" -m PyInstaller \
@@ -73,9 +74,9 @@ RESOURCES_DIR="$STAGE_DIR/Council.app/Contents/Resources"
 mkdir -p "$RESOURCES_DIR/backend" "$RESOURCES_DIR/runtime" "$RESOURCES_DIR/launcher"
 
 /usr/bin/ditto "$PYINSTALLER_DIST/council-backend" "$RESOURCES_DIR/backend/council-backend"
-/usr/bin/ditto "$PROJECT_DIR/frontend/.next/standalone" "$RESOURCES_DIR/web"
+/usr/bin/ditto "$PROJECT_DIR/frontend/$RELEASE_DIST_DIR/standalone" "$RESOURCES_DIR/web"
 mkdir -p "$RESOURCES_DIR/web/.next"
-/usr/bin/ditto "$PROJECT_DIR/frontend/.next/static" "$RESOURCES_DIR/web/.next/static"
+/usr/bin/ditto "$PROJECT_DIR/frontend/$RELEASE_DIST_DIR/static" "$RESOURCES_DIR/web/.next/static"
 cp "$NODE_RUNTIME_DIR/bin/node" "$RESOURCES_DIR/runtime/node"
 cp "$PROJECT_DIR/desktop/start-bundled.sh" "$RESOURCES_DIR/launcher/start-council.sh"
 cp "$PROJECT_DIR/desktop/stop-bundled.sh" "$RESOURCES_DIR/launcher/stop-council.sh"

--- a/packaging/build-windows-release.ps1
+++ b/packaging/build-windows-release.ps1
@@ -11,6 +11,7 @@ $StageDir = Join-Path $OutputRoot $PackageName
 $ZipPath = Join-Path $OutputRoot "$PackageName.zip"
 $PyInstallerWork = Join-Path $ProjectDir "build\pyinstaller-windows"
 $PyInstallerDist = Join-Path $ProjectDir "dist\pyinstaller-windows"
+$ReleaseDistDir = ".next-release"
 
 New-Item -ItemType Directory -Force -Path $OutputRoot, (Join-Path $ProjectDir "build"), (Join-Path $ProjectDir "dist") | Out-Null
 foreach ($Target in @($StageDir, $ZipPath, $PyInstallerWork, $PyInstallerDist)) {
@@ -19,15 +20,18 @@ foreach ($Target in @($StageDir, $ZipPath, $PyInstallerWork, $PyInstallerDist)) 
 
 Push-Location (Join-Path $ProjectDir "frontend")
 $PreviousStandalone = $env:COUNCIL_STANDALONE
+$PreviousNextDistDir = $env:COUNCIL_NEXT_DIST_DIR
 try {
     & npm.cmd ci --no-audit --no-fund
     if ($LASTEXITCODE -ne 0) { throw "npm ci failed" }
     $env:COUNCIL_STANDALONE = "1"
+    $env:COUNCIL_NEXT_DIST_DIR = $ReleaseDistDir
     & npm.cmd run build
     if ($LASTEXITCODE -ne 0) { throw "Next.js build failed" }
 }
 finally {
     if ($null -eq $PreviousStandalone) { Remove-Item Env:COUNCIL_STANDALONE -ErrorAction SilentlyContinue } else { $env:COUNCIL_STANDALONE = $PreviousStandalone }
+    if ($null -eq $PreviousNextDistDir) { Remove-Item Env:COUNCIL_NEXT_DIST_DIR -ErrorAction SilentlyContinue } else { $env:COUNCIL_NEXT_DIST_DIR = $PreviousNextDistDir }
     Pop-Location
 }
 
@@ -49,9 +53,9 @@ if ($LASTEXITCODE -ne 0) { throw "PyInstaller build failed" }
 
 New-Item -ItemType Directory -Force -Path $StageDir, (Join-Path $StageDir "backend"), (Join-Path $StageDir "runtime") | Out-Null
 Copy-Item -Recurse (Join-Path $PyInstallerDist "council-backend") (Join-Path $StageDir "backend\council-backend")
-Copy-Item -Recurse (Join-Path $ProjectDir "frontend\.next\standalone") (Join-Path $StageDir "web")
+Copy-Item -Recurse (Join-Path $ProjectDir "frontend\$ReleaseDistDir\standalone") (Join-Path $StageDir "web")
 New-Item -ItemType Directory -Force -Path (Join-Path $StageDir "web\.next") | Out-Null
-Copy-Item -Recurse (Join-Path $ProjectDir "frontend\.next\static") (Join-Path $StageDir "web\.next\static")
+Copy-Item -Recurse (Join-Path $ProjectDir "frontend\$ReleaseDistDir\static") (Join-Path $StageDir "web\.next\static")
 $NodeExe = (Get-Command node.exe -ErrorAction Stop).Source
 Copy-Item $NodeExe (Join-Path $StageDir "runtime\node.exe")
 Copy-Item (Join-Path $ProjectDir "desktop\start-bundled.ps1") (Join-Path $StageDir "runtime\start-council.ps1")

--- a/setup.sh
+++ b/setup.sh
@@ -33,7 +33,7 @@ printf '2/3 安装并构建网页...\n'
 (
   cd "$FRONTEND_DIR"
   npm ci --no-audit --no-fund
-  npm run build
+  COUNCIL_NEXT_DIST_DIR=.next-runtime npm run build
 )
 
 printf '3/3 创建启动入口...\n'


### PR DESCRIPTION
## 修复

- 将桌面运行构建固定到 `.next-runtime`
- 将发行打包固定到 `.next-release`
- 防止运行时服务与验证/发行构建互相覆盖 chunk
- 覆盖首席超时且无发言的失败 Run 回归

## 验证

- TypeScript、Vitest、release consistency tests 通过
- Playwright 失败 Run 用例通过
- 服务运行期间再次执行 `npm run build`，真实失败 Run 页面仍正常加载且控制台零错误