### PR TITLE
v0.17.0 fix: isolate native web view coordinator

### DIFF
--- a/macos/CouncilNative/Sources/CouncilNative/CouncilWebView.swift
+++ b/macos/CouncilNative/Sources/CouncilNative/CouncilWebView.swift
@@ -42,6 +42,7 @@ struct CouncilWebView: NSViewRepresentable {
         ))
     }
 
+    @MainActor
     final class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler {
         let navigation: CouncilNavigationModel
         var lastRequestID: UUID?


### PR DESCRIPTION
## Summary

Fix the macOS Release build under Swift 6.2 by isolating the WebKit coordinator on the main actor. WebKit delegate callbacks update AppKit navigation state, so this makes that thread-safety contract explicit without changing product behavior.

## Verification

- `swift test -c release --package-path macos/CouncilNative`: 4 passed
- `swift build -c release --package-path macos/CouncilNative`: passed
- `git diff --check`: passed

This unblocks the `v0.17.0` macOS and Windows release workflow. The existing `v0.17.0` tag has no GitHub Release because the first workflow stopped before publishing assets.
